### PR TITLE
Update devDependencies>mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.4.2"
+    "mocha": "^8.1.1"
   }
 }


### PR DESCRIPTION
Updating the devDependencies of mocha from ^3.4.2 to ^ 8.1.1 as there were 3 vulnerabilities detected when running `npm install`

https://npmjs.com/advisories/146
https://npmjs.com/advisories/534
https://npmjs.com/advisories/1179